### PR TITLE
Add wolves to world spawning

### DIFF
--- a/config/BiomeTweaker/blood.cfg
+++ b/config/BiomeTweaker/blood.cfg
@@ -1,3 +1,6 @@
+import pizzaluc.mods.*;
+import pizzaluc.*;
+import mods.Aggro_wolf
 Spawn = forBiomes(1)
 Spawn.set("isSpawnBiome",true)
 Blood = forAllBiomes()
@@ -14,6 +17,7 @@ Blood.set("enableRain",false)
 Blood.set("genVillages",false)
 Blood.set("waterTint", 13107200)
 Blood.removeAllSpawns("CREATURE")
+Blood.addSpawn("pizzaluc.mods.Agro_Wolfs", "CREATURE", 60, 1, 3)
 Blood.removeAllSpawns("WATER_CREATURE")
 Blood.removeDecoration("FLOWERS")
 Blood.removeDecoration("TREE")


### PR DESCRIPTION
Adds wolves to spawning. BiomeTweaker overrules the spawnrate, etc. so you can just ignore the Aggro_wolf config and change the 60,1,3 instead, if you want to tweak it